### PR TITLE
implement explicit free list

### DIFF
--- a/explicit-malloc-lab/mm.c
+++ b/explicit-malloc-lab/mm.c
@@ -1,13 +1,7 @@
 /*
- * mm-naive.c - The fastest, least memory-efficient malloc package.
+ * mm-explicit.c - 
  * 
- * In this naive approach, a block is allocated by simply incrementing
- * the brk pointer.  A block is pure payload. There are no headers or
- * footers.  Blocks are never coalesced or reused. Realloc is
- * implemented directly using mm_malloc and mm_free.
- *
- * NOTE TO STUDENTS: Replace this header comment with your own header
- * comment that gives a high level description of your solution.
+ * 
  */
 #include <stdio.h>
 #include <stdlib.h>
@@ -18,10 +12,6 @@
 #include "mm.h"
 #include "memlib.h"
 
-/*********************************************************
- * NOTE TO STUDENTS: Before you do anything else, please
- * provide your team information in the following struct.
- ********************************************************/
 team_t team = {
     /* Team name */
     "team7",
@@ -36,7 +26,7 @@ team_t team = {
 };
 
 /* single word (4) or double word (8) alignment */
-#define ALIGNMENT 8
+#define ALIGNMENT 16
 
 /* rounds up to the nearest multiple of ALIGNMENT */
 #define ALIGN(size) (((size) + (ALIGNMENT-1)) & ~0x7)
@@ -44,12 +34,7 @@ team_t team = {
 
 #define SIZE_T_SIZE (ALIGN(sizeof(size_t))) // allign 4byte
 
-/////////////////////////////////////////////
-/*              define macro               */
-#define FIT 1 // fit
-#define EXPLICIT 1 // explicit(pred, succ)
-
-
+/* ----------------------------- define macro ----------------------------- */
 #define WSIZE 4 // word
 #define DSIZE 8 // double word
 #define CHUNKSIZE (1<<12)
@@ -70,36 +55,84 @@ team_t team = {
 #define NEXT_BLKP(bp) ((char *)(bp) + GET_SIZE(HDRP(bp))) // 다음 블록의 주소 계산
 #define PREV_BLKP(bp) ((char *)(bp) - GET_SIZE((char *)(bp) - DSIZE)) // 이전 블록의 주소 계산
 
-/* explicit */
-#define PRED(bp) (*(void**)(bp)) // points the value of bp(address of prev)
-#define SUCC(bp) (*(void**)(bp + WSIZE)) // points the value of (bp + WSIZE) (address of succ)
-/////////////////////////////////////////////
+#define PRED(bp) (*(char **)(bp)) // 이전 가용 블록
+#define SUCC(bp) (*(char **)(bp + WSIZE)) // 다음 가용 블록
+/* ------------------------------------------------------------------------ */
 
-/* Global variants */
-static char *heap_listp = NULL; // points prologue
-static char *lastp = NULL; // save previous search point for next fit
+/* -------------------------- function prototype -------------------------- */
+static void *coalesce(void*);
+static void *extend_heap(size_t);
+static void *find_fit(size_t);
+static void place(void*, size_t);
 
-/* explicit */
-static char *free_listp = NULL; // points free list pred
+static void put_free_block(void*);
+static void remove_free_block(void*);
+/* ------------------------------------------------------------------------ */
 
-void removeBlock(void *bp) {
-    // remove first block
-    if (bp == free_listp) {
-        PRED(SUCC(bp)) = NULL; // second block becomes first block
-        free_listp = SUCC(bp);
-    }
-    else {
-        SUCC(PRED(bp)) = SUCC(bp); // and concat prev and next
-        PRED(SUCC(bp)) = PRED(bp); // remove block
-    }
+/* ---------------------------- global variants --------------------------- */
+static char *heap_listp = 0; // points prologue
+static char *free_listp = 0; // 가용 리스트 첫 블록 pred
+/* ------------------------------------------------------------------------ */
+
+/* 
+ * mm_init - initialize the malloc package.
+ */
+
+int mm_init(void)
+{   
+    // cannot allocate mandatory 6 blocks(padding, prologue, footer) ...
+    // + pred, succ (각 4바이트)
+    heap_listp = mem_sbrk(6 * WSIZE);
+    if (heap_listp == (void *)-1)
+        return -1;
+
+    PUT(heap_listp, 0); // padding
+    PUT(heap_listp + (1 * WSIZE), PACK(2 * DSIZE, 1)); // prologue header (4byte)
+    PUT(heap_listp + (2 * WSIZE), NULL); // pred == NULL
+    PUT(heap_listp + (3 * WSIZE), NULL); // succ == NULL
+    PUT(heap_listp + (4 * WSIZE), PACK(2 * DSIZE, 1)); // prologue footer (4byte)
+    PUT(heap_listp + (5 * WSIZE), PACK(0, 1)); // epilogue header (0byte)
+
+    free_listp = heap_listp + 2 * WSIZE; // pred를 가리킴(payload 시작점)
+
+    // extend until chunksize
+    if (extend_heap(CHUNKSIZE / WSIZE) == NULL)
+        return -1;
+
+    return 0;
 }
 
-void putFreeBlock(void *bp) {
-    // place free block in front of free list (LIFO)
-    SUCC(bp) = free_listp;
-    PRED(bp) = NULL;
-    PRED(free_listp) = bp;
-    free_listp = bp;
+/* 
+ * mm_malloc - Allocate a block by incrementing the brk pointer.
+ *     Always allocate a block whose size is a multiple of the alignment.
+ */
+
+void *mm_malloc(size_t size)
+{
+    size_t asize;
+    size_t extendsize;
+    char *bp;
+
+    // return if requesting size 0 block
+    if (size == 0) 
+        return NULL;
+    
+    // 8 byte allignment
+    asize = ALIGN(size + SIZE_T_SIZE);
+
+    // search free space
+    if ((bp = find_fit(asize)) != NULL) {
+        place(bp, asize);
+        return bp;
+    }
+
+    // no free space... extend heap
+    extendsize = MAX(asize, CHUNKSIZE);
+    if ((bp = extend_heap(extendsize / WSIZE)) == NULL) 
+        return NULL;
+    place(bp, asize);
+
+    return bp;
 }
 
 static void *coalesce(void *bp) {
@@ -108,18 +141,13 @@ static void *coalesce(void *bp) {
     size_t size = GET_SIZE(HDRP(bp));
 
     // case 1: both allocated
-    // if (prev_alloc && next_alloc) {
-        
-    //     // lastp = bp;
-    //     return bp;
-    // }
+    // 해당 블록만 가용 리스트에 추가
 
     // case 2: next is free
     if (prev_alloc && !next_alloc) {
-        #if EXPLICIT == 1
-        removeBlock(NEXT_BLKP(bp)); // next block is removed from free list
-        #endif
-        
+        // printf("case 2\n");
+        remove_free_block(NEXT_BLKP(bp)); // next 블록 가용 리스트에서 삭제
+
         size += GET_SIZE(HDRP(NEXT_BLKP(bp))); // coalesce next block
         PUT(HDRP(bp), PACK(size, 0)); // update header
         PUT(FTRP(bp), PACK(size, 0)); // update footer
@@ -127,46 +155,32 @@ static void *coalesce(void *bp) {
 
     // case 3: prev is free
     else if (!prev_alloc && next_alloc) {
-        // printf("case3\n");
+        // printf("case 3\n");
 
-        #if EXPLICIT == 1
-        removeBlock(PREV_BLKP(bp));
-        #endif
-        
+        // printf("이전 블록: %p\n", PREV_BLKP(bp));
+        remove_free_block(PREV_BLKP(bp)); // prev 블록 가용 리스트에서 삭제
+
         size += GET_SIZE(HDRP(PREV_BLKP(bp))); // coalesce prev block
-        
-        #if EXPLICIT == 1
         bp = PREV_BLKP(bp);
-        PUT(FTRP(bp), PACK(size, 0)); // update footer
         PUT(HDRP(bp), PACK(size, 0)); // update header
-        #else
         PUT(FTRP(bp), PACK(size, 0)); // update footer
-        PUT(HDRP(PREV_BLKP(bp)), PACK(size, 0)); // update header
-        bp = PREV_BLKP(bp);
-        #endif
     }
 
     // case 4: both free
     else if (!prev_alloc && !next_alloc) {
-        // printf("case4\n");
+        // printf("case 4\n");
 
-        #if EXPLICIT == 1
-        removeBlock(PREV_BLKP(bp));
-        removeBlock(NEXT_BLKP(bp));
-        #endif 
+        remove_free_block(PREV_BLKP(bp)); // next 블록 가용 리스트에서 삭제
+        remove_free_block(NEXT_BLKP(bp)); // prev 블록 가용 리스트에서 삭제
 
-        size += GET_SIZE(HDRP(PREV_BLKP(bp))) + GET_SIZE(FTRP(NEXT_BLKP(bp)));
+        size += GET_SIZE(HDRP(PREV_BLKP(bp))) + GET_SIZE(HDRP(NEXT_BLKP(bp)));
+        PUT(HDRP(PREV_BLKP(bp)), PACK(size, 0));
+        PUT(FTRP(NEXT_BLKP(bp)), PACK(size, 0));
         bp = PREV_BLKP(bp);
-        PUT(HDRP(bp), PACK(size, 0));
-        PUT(FTRP(bp), PACK(size, 0));
     }
+    // printf("case 1\n");
+    put_free_block(bp);
 
-
-    #if EXPLICIT == 1
-    putFreeBlock(bp);
-    #endif
-
-    // lastp = bp;
     return bp;    
 }
 
@@ -177,7 +191,7 @@ static void *extend_heap(size_t words) {
     // for 8 byte allignment
     size = (words % 2) ? (words + 1) * WSIZE : words * WSIZE;
     // cant extend until size
-    if ((bp = mem_sbrk(size)) == (void *)-1) {
+    if ((long)(bp = mem_sbrk(size)) == -1) {
         return NULL;
     }
         
@@ -189,201 +203,57 @@ static void *extend_heap(size_t words) {
     return coalesce(bp);
 }
 
-/* 
- * mm_init - initialize the malloc package.
- */
-
-int mm_init(void)
-{   
-    // printf("init\n");
-    #if EXPLICIT == 1
-    // cannot allocate mandatory 6 blocks(padding, prologue, footer + Pred, Succ) ...
-    if ((heap_listp = mem_sbrk(6 * WSIZE)) == (void *)-1)
-        return -1;
-    #else
-    // cannot allocate mandatory 4 blocks(padding, prologue, footer) ...
-    if ((heap_listp = mem_sbrk(4 * WSIZE)) == (void *)-1)
-        return -1;
-    #endif
-
-
-    #if EXPLICIT == 1
-    PUT(heap_listp, 0); // padding
-    PUT(heap_listp + (1 * WSIZE), PACK(2 * DSIZE, 1)); // prologue header (4byte)
-    PUT(heap_listp + (2 * WSIZE), NULL); // PRED
-    PUT(heap_listp + (3 * WSIZE), NULL); // SUCC
-    PUT(heap_listp + (4 * WSIZE), PACK(2 * DSIZE, 1)); // prologue footer (4byte)
-    PUT(heap_listp + (5 * WSIZE), PACK(0, 1)); // epilogue header (0byte)
-    free_listp = heap_listp + DSIZE; // free_listp points pred
-    // heap_listp += (4 * WSIZE); // heap_listp points prologue footer
-    
-    #else
-    PUT(heap_listp, 0); // padding
-    PUT(heap_listp + (1 * WSIZE), PACK(DSIZE, 1)); // prologue header (4byte)
-    PUT(heap_listp + (2 * WSIZE), PACK(DSIZE, 1)); // prologue footer (4byte)
-    PUT(heap_listp + (3 * WSIZE), PACK(0, 1)); // epilogue header (0byte)
-    heap_listp += (2 * WSIZE); // heap_listp points prologue footer
-    #endif
-
-    // lastp = heap_listp;
-    
-    // extend until chunksize
-    if (extend_heap(CHUNKSIZE / WSIZE) == NULL) {
-        return -1;
-    }
-    // printf("init 완료\n");
-    return 0;
-}
-
-/* 
- * mm_malloc - Allocate a block by incrementing the brk pointer.
- *     Always allocate a block whose size is a multiple of the alignment.
- */
-
-#if FIT == 1
-// first fit - 71
+// first fit
 static void *find_fit(size_t asize) {
     void *bp;
     // printf("exec first fit...\n");
     // iterate heap space
-    // printf("findfit\n");
-    #if EXPLICIT == 1
-    // find allocatable block from free list
-    for (bp = free_listp; GET_ALLOC(HDRP(bp)) != 1; bp = SUCC(bp)) {
-        if (asize <= GET_SIZE(HDRP(bp)))
+    for (bp = free_listp; GET_ALLOC(HDRP(bp)) == 0; bp = SUCC(bp)) { // 가용 리스트의 마지막은 프롤로그 블록
+        if (asize <= GET_SIZE(HDRP(bp))) // if free and allocatable
             return bp;
     }
-
-    #else
-    for (bp = heap_listp; GET_SIZE(HDRP(bp)) > 0; bp = NEXT_BLKP(bp)) {
-        //printf("now block %d\n", GET(bp));
-        if (!GET_ALLOC(HDRP(bp)) && asize <= GET_SIZE(HDRP(bp))) // if free and allocatable
-            return bp;
-    }
-    #endif
 
     return NULL;
 }
-
-#elif FIT == 2
-// next fit - 83
-static void *find_fit(size_t asize) {
-    void *bp;
-    void *old_lastp = lastp;
-    
-    for (bp = lastp; GET_SIZE(HDRP(bp)) > 0; bp = NEXT_BLKP(bp)) {
-        if (!GET_ALLOC(HDRP(bp)) && asize <= GET_SIZE(HDRP(bp))) { // if free and allocatable
-            lastp = NEXT_BLKP(bp);
-            return bp;
-        }
-    }
-
-    // cant find 
-    for (bp = heap_listp; bp < old_lastp; bp = NEXT_BLKP(bp)) {
-        if (!GET_ALLOC(HDRP(bp)) && asize <= GET_SIZE(HDRP(bp))) { // if free and allocatable
-            lastp = NEXT_BLKP(bp);
-            return bp;
-        }
-    }
-    
-    return NULL;
-}
-
-#elif FIT == 3
-// best fit - 61
-static void *find_fit(size_t asize) {
-    void *bp;
-    void *best = NULL;
-
-    for (bp = heap_listp; GET_SIZE(HDRP(bp)) > 0; bp = NEXT_BLKP(bp)) {
-        if (!GET_ALLOC(HDRP(bp)) && asize <= GET_SIZE(HDRP(bp))) { // if free and allocatable
-            if (best == NULL)
-                best = bp;
-            if (GET_SIZE(HDRP(bp)) <= GET_SIZE(HDRP(best)))
-                best = bp;
-        }
-    }
-
-    return best;
-}
-#endif
 
 // divide block (minimum block is 8byte)
 static void place(void *bp, size_t asize) {
     size_t csize = GET_SIZE(HDRP(bp)); // size of block now
-    // printf("place\n");
-    #if EXPLICIT == 1
-    removeBlock(bp);
-    #endif
+    remove_free_block(bp); // 일단 가용리스트에서 삭제
 
-    #if EXPLICIT == 1
-    if ((csize - asize) >= (2 * DSIZE)) // divide
-    #else
-    if ((csize - asize) >= (DSIZE)) // divide
-    #endif
-    {
-        // printf("divide\n");
+
+    if ((csize - asize) >= (2 * DSIZE)) { // divide
         PUT(HDRP(bp), PACK(asize, 1)); // allocate asize
         PUT(FTRP(bp), PACK(asize, 1));
-
         bp = NEXT_BLKP(bp); // divide block
         PUT(HDRP(bp), PACK(csize - asize, 0)); // allocate csize - asize
         PUT(FTRP(bp), PACK(csize - asize, 0));
 
-        #if EXPLICIT == 1
-        putFreeBlock(bp);
-        #endif
+        put_free_block(bp); // 분할 가능하면 남은 부분 가용 리스트에 추가
     }
     else {
-        // printf("no divide\n");
         PUT(HDRP(bp), PACK(csize, 1));
         PUT(FTRP(bp), PACK(csize, 1));
     }
-    // printf("Place fin.\n");
 }
 
-void *mm_malloc(size_t size)
-{
-    size_t asize;
-    size_t extendsize;
-    char *bp;
+static void put_free_block(void* bp) {
+    // 가용 리스트 앞에 추가 (LIFO)
+    SUCC(bp) = free_listp;
+    PRED(bp) = NULL;
+    PRED(free_listp) = bp;
+    free_listp = bp;
+}
 
-    // return if requesting size 0 block
-    if (size <= 0) 
-        return NULL;
-    
-    // allignment
-    if (size <= DSIZE)
-        asize = 2 * DSIZE;
-    else
-        asize = DSIZE * ((size + DSIZE + (DSIZE - 1)) / DSIZE);
-
-    // search free space
-    if ((bp = find_fit(asize)) != NULL) {
-        // printf("malloc find fit\n");
-        place(bp, asize);
-        // lastp = bp;
-        return bp;
+static void remove_free_block(void* bp) {
+    if (bp == free_listp) { // 첫 블록 삭제
+        PRED(SUCC(bp)) = NULL;
+        free_listp = SUCC(bp);
     }
-
-    // no free space... extend heap
-    extendsize = MAX(asize, CHUNKSIZE);
-    // printf("malloc extend heap\n");
-    if ((bp = extend_heap(extendsize / WSIZE)) == NULL) 
-        return NULL;
-    place(bp, asize);
-    // lastp = bp; // save last search point
-    return bp;
-
-    // basic malloc
-    // int newsize = ALIGN(size + SIZE_T_SIZE);
-    // void *p = mem_sbrk(newsize);
-    // if (p == (void *)-1)
-	// return NULL;
-    // else {
-    //     *(size_t *)p = size;
-    //     return (void *)((char *)p + SIZE_T_SIZE);
-    // }
+    else {
+        SUCC(PRED(bp)) = SUCC(bp);
+        PRED(SUCC(bp)) = PRED(bp);
+    }
 }
 
 /*
@@ -391,6 +261,10 @@ void *mm_malloc(size_t size)
  */
 void mm_free(void *ptr)
 {
+    // ignore spurious requests.
+    if (ptr == NULL)
+        return;
+
     size_t size = GET_SIZE(HDRP(ptr));
     
     PUT(HDRP(ptr), PACK(size, 0)); // make block available
@@ -409,14 +283,14 @@ void *mm_realloc(void *ptr, size_t size)
     void *newptr;
     size_t copySize = GET_SIZE(HDRP(oldptr));
 
-    // 1. realloc from NULL == malloc
+    // realloc from NULL == malloc
     if (ptr == NULL) {
         // printf("Case 1\n");
         return mm_malloc(size);
     }
 
     // 2. change ptr block size to 0 == free block
-    if (size <= 0) { 
+    if (size == 0) { 
         // printf("Case 2\n");
         mm_free(ptr);
         return NULL;
@@ -429,21 +303,34 @@ void *mm_realloc(void *ptr, size_t size)
     }
 
     // 4. bigger size
-    // size_t bsize = copySize + GET_SIZE(HDRP(NEXT_BLKP(oldptr)));
-    // size_t asize = ALIGN(size + SIZE_T_SIZE);
+    size_t bsize = copySize + GET_SIZE(HDRP(NEXT_BLKP(oldptr)));
+    size_t asize = ALIGN(size + SIZE_T_SIZE);
 
-    // // next is available and size is enough
-    // if (!GET_ALLOC(HDRP(NEXT_BLKP(oldptr))) && (size + DSIZE <= bsize)) {
-    //     // printf("Case 4\n");
-    //     // PUT(HDRP(ptr), PACK(bsize, 1)); // 1 is alloc, 0 is free
-    //     // PUT(FTRP(ptr), PACK(bsize, 1));
-    //     // place(ptr, asize); // divide
-    //     // lastp = ptr; // save last search point
-    //     PUT(HDRP(oldptr), PACK(bsize, 1)); // 1 is alloc, 0 is free
-    //     PUT(FTRP(oldptr), PACK(bsize, 1));
+    // next is available and size is enough
+    if (!GET_ALLOC(HDRP(NEXT_BLKP(oldptr))) && (size + DSIZE <= bsize)) {
+        // printf("Case 4\n");
+        remove_free_block(NEXT_BLKP(oldptr));
+
+        // 블록에 여유 공간 있으면 분할 -> 82
+        // if (bsize - asize < 2 * DSIZE) {
+        //     PUT(HDRP(oldptr), PACK(bsize, 1)); // 1 is alloc, 0 is free
+        //     PUT(FTRP(oldptr), PACK(bsize, 1));
+        // }
+        // else {
+        //     PUT(HDRP(oldptr), PACK(asize, 1)); // 1 is alloc, 0 is free
+        //     PUT(FTRP(oldptr), PACK(asize, 1));
+
+        //     put_free_block(NEXT_BLKP(oldptr));
+        //     PUT(HDRP(NEXT_BLKP(oldptr)), PACK(bsize - asize, 0));
+        //     PUT(FTRP(NEXT_BLKP(oldptr)), PACK(bsize - asize, 0));
+        // }
+
+        // 분할 안하고 그냥 할당 -> 85
+        PUT(HDRP(oldptr), PACK(bsize, 1)); // 1 is alloc, 0 is free
+        PUT(FTRP(oldptr), PACK(bsize, 1));
         
-    //     return oldptr;
-    // }
+        return ptr;
+    }
 
     newptr = mm_malloc(size);
     if (newptr == NULL)
@@ -451,7 +338,7 @@ void *mm_realloc(void *ptr, size_t size)
 
     if (size < copySize)
       copySize = size;
-    memcpy(newptr, oldptr, copySize);
+    memmove(newptr, oldptr, copySize);
     mm_free(oldptr);
     return newptr;
 

--- a/implicit-malloc-lab/mm.c
+++ b/implicit-malloc-lab/mm.c
@@ -1,13 +1,7 @@
 /*
- * mm-naive.c - The fastest, least memory-efficient malloc package.
+ * mm-implicit.c - 
  * 
- * In this naive approach, a block is allocated by simply incrementing
- * the brk pointer.  A block is pure payload. There are no headers or
- * footers.  Blocks are never coalesced or reused. Realloc is
- * implemented directly using mm_malloc and mm_free.
- *
- * NOTE TO STUDENTS: Replace this header comment with your own header
- * comment that gives a high level description of your solution.
+ * 
  */
 #include <stdio.h>
 #include <stdlib.h>
@@ -18,10 +12,6 @@
 #include "mm.h"
 #include "memlib.h"
 
-/*********************************************************
- * NOTE TO STUDENTS: Before you do anything else, please
- * provide your team information in the following struct.
- ********************************************************/
 team_t team = {
     /* Team name */
     "team7",
@@ -44,10 +34,8 @@ team_t team = {
 
 #define SIZE_T_SIZE (ALIGN(sizeof(size_t))) // allign 4byte
 
-/////////////////////////////////////////////
-/*              define macro               */
+/* ----------------------------- define macro ----------------------------- */
 #define FIT 2 // fit
-
 
 #define WSIZE 4 // word
 #define DSIZE 8 // double word
@@ -68,10 +56,87 @@ team_t team = {
 
 #define NEXT_BLKP(bp) ((char *)(bp) + GET_SIZE(HDRP(bp))) // 다음 블록의 주소 계산
 #define PREV_BLKP(bp) ((char *)(bp) - GET_SIZE((char *)(bp) - DSIZE)) // 이전 블록의 주소 계산
-/////////////////////////////////////////////
+/* ------------------------------------------------------------------------ */
 
+/* -------------------------- function prototype -------------------------- */
+static void *coalesce(void*);
+static void *extend_heap(size_t);
+static void *find_fit(size_t);
+static void place(void*, size_t);
+/* ------------------------------------------------------------------------ */
+
+/* ---------------------------- global variants --------------------------- */
 static char *heap_listp; // points prologue
 char *lastp; // save previous search point for next fit
+/* ------------------------------------------------------------------------ */
+
+/* 
+ * mm_init - initialize the malloc package.
+ */
+
+int mm_init(void)
+{   
+    // cannot allocate mandatory 4 blocks(padding, prologue, footer) ...
+    if ((heap_listp = mem_sbrk(4 * WSIZE)) == (void *)-1)
+        return -1;
+
+    PUT(heap_listp, 0); // padding
+    PUT(heap_listp + (1 * WSIZE), PACK(DSIZE, 1)); // prologue header (4byte)
+    PUT(heap_listp + (2 * WSIZE), PACK(DSIZE, 1)); // prologue footer (4byte)
+    PUT(heap_listp + (3 * WSIZE), PACK(0, 1)); // epilogue header (0byte)
+    heap_listp += (2 * WSIZE); // heap_listp points prologue footer
+    lastp = heap_listp;
+
+    // extend until chunksize
+    if (extend_heap(CHUNKSIZE / WSIZE) == NULL)
+        return -1;
+
+    return 0;
+}
+
+/* 
+ * mm_malloc - Allocate a block by incrementing the brk pointer.
+ *     Always allocate a block whose size is a multiple of the alignment.
+ */
+
+void *mm_malloc(size_t size)
+{
+    size_t asize;
+    size_t extendsize;
+    char *bp;
+
+    // return if requesting size 0 block
+    if (size == 0) 
+        return NULL;
+    
+    // 8 byte allignment
+    asize = ALIGN(size + SIZE_T_SIZE);
+
+    // search free space
+    if ((bp = find_fit(asize)) != NULL) {
+        place(bp, asize);
+        lastp = bp;
+        return bp;
+    }
+
+    // no free space... extend heap
+    extendsize = MAX(asize, CHUNKSIZE);
+    if ((bp = extend_heap(extendsize / WSIZE)) == NULL) 
+        return NULL;
+    place(bp, asize);
+    lastp = bp; // save last search point
+    return bp;
+
+    // basic malloc
+    // int newsize = ALIGN(size + SIZE_T_SIZE);
+    // void *p = mem_sbrk(newsize);
+    // if (p == (void *)-1)
+	// return NULL;
+    // else {
+    //     *(size_t *)p = size;
+    //     return (void *)((char *)p + SIZE_T_SIZE);
+    // }
+}
 
 static void *coalesce(void *bp) {
     size_t prev_alloc = GET_ALLOC(FTRP(PREV_BLKP(bp))); // allocation of prev block
@@ -130,35 +195,6 @@ static void *extend_heap(size_t words) {
     return coalesce(bp);
 }
 
-/* 
- * mm_init - initialize the malloc package.
- */
-
-int mm_init(void)
-{   
-    // cannot allocate mandatory 4 blocks(padding, prologue, footer) ...
-    if ((heap_listp = mem_sbrk(4 * WSIZE)) == (void *)-1)
-        return -1;
-
-    PUT(heap_listp, 0); // padding
-    PUT(heap_listp + (1 * WSIZE), PACK(DSIZE, 1)); // prologue header (4byte)
-    PUT(heap_listp + (2 * WSIZE), PACK(DSIZE, 1)); // prologue footer (4byte)
-    PUT(heap_listp + (3 * WSIZE), PACK(0, 1)); // epilogue header (0byte)
-    heap_listp += (2 * WSIZE); // heap_listp points prologue footer
-    lastp = heap_listp;
-
-    // extend until chunksize
-    if (extend_heap(CHUNKSIZE / WSIZE) == NULL)
-        return -1;
-
-    return 0;
-}
-
-/* 
- * mm_malloc - Allocate a block by incrementing the brk pointer.
- *     Always allocate a block whose size is a multiple of the alignment.
- */
-
 #if FIT == 1
 // first fit
 static void *find_fit(size_t asize) {
@@ -166,7 +202,6 @@ static void *find_fit(size_t asize) {
     // printf("exec first fit...\n");
     // iterate heap space
     for (bp = heap_listp; GET_SIZE(HDRP(bp)) > 0; bp = NEXT_BLKP(bp)) {
-        //printf("now block %d\n", GET(bp));
         if (!GET_ALLOC(HDRP(bp)) && asize <= GET_SIZE(HDRP(bp))) // if free and allocatable
             return bp;
     }
@@ -221,7 +256,7 @@ static void *find_fit(size_t asize) {
 static void place(void *bp, size_t asize) {
     size_t csize = GET_SIZE(HDRP(bp)); // size of block now
 
-    if ((csize - asize) >= (DSIZE)) { // divide
+    if ((csize - asize) >= (2 * DSIZE)) { // divide
         PUT(HDRP(bp), PACK(asize, 1)); // allocate asize
         PUT(FTRP(bp), PACK(asize, 1));
         bp = NEXT_BLKP(bp); // divide block
@@ -232,45 +267,6 @@ static void place(void *bp, size_t asize) {
         PUT(HDRP(bp), PACK(csize, 1));
         PUT(FTRP(bp), PACK(csize, 1));
     }
-}
-
-void *mm_malloc(size_t size)
-{
-    size_t asize;
-    size_t extendsize;
-    char *bp;
-
-    // return if requesting size 0 block
-    if (size == 0) 
-        return NULL;
-    
-    // 8 byte allignment
-    asize = ALIGN(size + SIZE_T_SIZE);
-
-    // search free space
-    if ((bp = find_fit(asize)) != NULL) {
-        place(bp, asize);
-        lastp = bp;
-        return bp;
-    }
-
-    // no free space... extend heap
-    extendsize = MAX(asize, CHUNKSIZE);
-    if ((bp = extend_heap(extendsize / WSIZE)) == NULL) 
-        return NULL;
-    place(bp, asize);
-    lastp = bp; // save last search point
-    return bp;
-
-    // basic malloc
-    // int newsize = ALIGN(size + SIZE_T_SIZE);
-    // void *p = mem_sbrk(newsize);
-    // if (p == (void *)-1)
-	// return NULL;
-    // else {
-    //     *(size_t *)p = size;
-    //     return (void *)((char *)p + SIZE_T_SIZE);
-    // }
 }
 
 /*
@@ -292,9 +288,8 @@ void mm_free(void *ptr)
 // mm_malloc이 find fit, extend heap을 하고 있음
 void *mm_realloc(void *ptr, size_t size)
 {
-    void *oldptr = ptr;
     void *newptr;
-    size_t copySize = GET_SIZE(HDRP(oldptr));
+    size_t copySize = GET_SIZE(HDRP(ptr));
 
     // 1. realloc from NULL == malloc
     if (ptr == NULL) {
@@ -316,15 +311,15 @@ void *mm_realloc(void *ptr, size_t size)
     }
 
     // 4. bigger size
-    size_t bsize = copySize + GET_SIZE(HDRP(NEXT_BLKP(oldptr)));
-    size_t asize = ALIGN(size + SIZE_T_SIZE);
+    size_t bsize = copySize + GET_SIZE(HDRP(NEXT_BLKP(ptr)));
+    // size_t asize = ALIGN(size + SIZE_T_SIZE);
 
     // next is available and size is enough
-    if (!GET_ALLOC(HDRP(NEXT_BLKP(oldptr))) && (size + DSIZE <= bsize)) {
+    if (!GET_ALLOC(HDRP(NEXT_BLKP(ptr))) && (size + DSIZE <= bsize)) {
         // printf("Case 4\n");
         PUT(HDRP(ptr), PACK(bsize, 1)); // 1 is alloc, 0 is free
         PUT(FTRP(ptr), PACK(bsize, 1));
-        place(ptr, asize); // divide
+        // place(ptr, asize); // divide
         lastp = ptr; // save last search point
         return ptr;
     }
@@ -335,8 +330,8 @@ void *mm_realloc(void *ptr, size_t size)
 
     if (size < copySize)
       copySize = size;
-    memmove(newptr, oldptr, copySize);
-    mm_free(oldptr);
+    memmove(newptr, ptr, copySize);
+    mm_free(ptr);
     return newptr;
 
 }


### PR DESCRIPTION
explicit scores
---

```
Results for mm malloc:
trace  valid  util     ops      secs  Kops
 0       yes   88%    5694  0.000648  8788
 1       yes   91%    5848  0.000585 10005
 2       yes   94%    6648  0.000777  8560
 3       yes   96%    5380  0.000658  8174
 4       yes   66%   14400  0.001119 12870
 5       yes   88%    4800  0.000832  5766
 6       yes   85%    4800  0.000875  5484
 7       yes   52%   12000  0.005190  2312
 8       yes   44%   24000  0.004073  5893
 9       yes   42%   14401  0.003500  4115
10       yes   85%   14401  0.001076 13390
Total          76%  112372  0.019332  5813

Perf index = 45 (util) + 40 (thru) = 85/100
```

- realloc case 4에서 분할(place) 안하고 그냥 통으로 주는게 2점 높음

---

- 분할 한 경우

```
Results for mm malloc:
trace  valid  util     ops      secs  Kops
 0       yes   88%    5694  0.000815  6988
 1       yes   91%    5848  0.000640  9138
 2       yes   94%    6648  0.001525  4360
 3       yes   96%    5380  0.000661  8140
 4       yes   66%   14400  0.001156 12462
 5       yes   88%    4800  0.000909  5281
 6       yes   85%    4800  0.000868  5533
 7       yes   52%   12000  0.005263  2280
 8       yes   44%   24000  0.004927  4871
 9       yes   33%   14401  0.118942   121
10       yes   29%   14401  0.004155  3466
Total          70%  112372  0.139860   803

Perf index = 42 (util) + 40 (thru) = 82/100
```
